### PR TITLE
Refactor run.sh: added custom build-plan file and build plan checks; improved messaging

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -61,7 +61,7 @@ file "v${FONT_VERSION}.tar.gz" | grep 'gzip compressed data' > /dev/null
 tar -xf "v${FONT_VERSION}.tar.gz"
 cd ./*Iosevka-*
 
-if [[ -n $CUSTOM_BUILD_FILE ]]; then
+if [ "$CUSTOM_BUILD_FILE" = true ]; then
     cp "/build/$BUILD_FILE" .
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -28,10 +28,6 @@ if [[ -f "/build/$BUILD_FILE" ]]; then
     fi
 else
     echo "Custom build-plans file not found, using the default one"
-    if [[ -n $1 ]]; then
-        echo -e "\nError: Custom build plan '$1' requested, but custom '$BUILD_FILE' file not found"
-        exit 1
-    fi
 fi
 
 echo "Using build plan: $BUILD_PARAM"

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Based on https://github.com/ejuarezg/containers/blob/master/iosevka_font/run.sh
 
 set -e
@@ -7,14 +7,43 @@ set -e
 mkdir /tmp/build
 cd /tmp/build
 
-# Find the latest font version if the font version environment variable is not
-# set. The `-n` operator checks if the length of the string is nonzero.
-if [ ! -n "$FONT_VERSION" ]; then
-    FONT_VERSION=$(curl -s -L https://github.com/be5invis/Iosevka/releases/latest \
-        | grep -Po '(?<=tag/v)[0-9.]*' | head -1)
+BUILD_FILE="private-build-plans.toml"
+BUILD_PARAM="contents::iosevka"
+
+CUSTOM_BUILD_FILE=false
+
+# Check the input
+if [[ -f "/build/$BUILD_FILE" ]]; then
+    echo "Found custom build-plans file: $BUILD_FILE"
+    CUSTOM_BUILD_FILE=true
+    if [[ -z $1 ]]; then
+        # Get the name of the first build plan when the user does not provide
+        # custom build arguments (automatic mode)
+        PLAN_NAME=$(grep -Po -m 1 '(?<=buildPlans.)[^\]]*' $BUILD_FILE)
+        BUILD_PARAM="contents::$PLAN_NAME"
+    else
+        # User knows what they are doing and provided custom build arguments
+        # (manual mode)
+        BUILD_PARAM="$1"
+    fi
+else
+    echo "Custom build-plans file not found, using the default one"
+    if [[ -n $1 ]]; then
+        echo -e "\nError: Custom build plan '$1' requested, but custom '$BUILD_FILE' file not found"
+        exit 1
+    fi
 fi
 
-echo FONT_VERSION="$FONT_VERSION"
+echo "Using build plan: $BUILD_PARAM"
+
+# Find the latest font version if the font version environment variable is not
+# set. The `-n` operator checks if the length of the string is nonzero.
+if [[ -z "$FONT_VERSION" ]]; then
+    FONT_VERSION=$(curl -s -L https://github.com/be5invis/Iosevka/releases/latest \
+        | grep -Po -m 1 '(?<=tag/v)[0-9.]*')
+fi
+
+echo "Using font version: ${FONT_VERSION}"
 
 echo "Downloading and checking the validity of the source code..."
 
@@ -29,31 +58,16 @@ fi
 file "v${FONT_VERSION}.tar.gz" | grep 'gzip compressed data' > /dev/null
 
 # Extract downloaded source code
-tar -xf v${FONT_VERSION}.tar.gz
-cd *Iosevka-*
+tar -xf "v${FONT_VERSION}.tar.gz"
+cd ./*Iosevka-*
+
+if [[ -n $CUSTOM_BUILD_FILE ]]; then
+    cp "/build/$BUILD_FILE" .
+fi
 
 echo "Building version ${FONT_VERSION}"
 npm install
-
-if ! test -f "/build/private-build-plans.toml"; then
-	echo "No private-build-plans.toml found. Proceeding with the standard build"
-	npm run build -- contents::iosevka
-else
-	cp /build/private-build-plans.toml .
-	echo "Using the provided build-plans file.."
-	# No arguments passed
-	if [ $# -eq 0 ]; then
-    		# Get the name of the first build plan when the user does not provide
-    		# custom build arguments (automatic mode)
-    		PLAN_NAME=$(grep -Po -m 1 '(?<=buildPlans.)[^\]]*' private-build-plans.toml)
-
-    		npm run build -- contents::$PLAN_NAME
-	else
-    		# User knows what they are doing and provided custom build arguments
-    		# (manual mode)
-    		npm run build -- "$@"
-	fi
-fi
+npm run build -- "$BUILD_PARAM"
 
 # Copy the dist folder back to the mounted volume
 cp -r dist /build/

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ if [[ -f "/build/$BUILD_FILE" ]]; then
     if [[ -z $1 ]]; then
         # Get the name of the first build plan when the user does not provide
         # custom build arguments (automatic mode)
-        PLAN_NAME=$(grep -Po -m 1 '(?<=buildPlans.)[^\]]*' $BUILD_FILE)
+        PLAN_NAME=$(grep -Po -m 1 '(?<=buildPlans.)[^\]]*' /build/$BUILD_FILE)
         BUILD_PARAM="contents::$PLAN_NAME"
     else
         # User knows what they are doing and provided custom build arguments

--- a/run.sh
+++ b/run.sh
@@ -10,9 +10,11 @@ cd /tmp/build
 # Find the latest font version if the font version environment variable is not
 # set. The `-n` operator checks if the length of the string is nonzero.
 if [ ! -n "$FONT_VERSION" ]; then
-    FONT_VERSION=$(curl -s https://github.com/be5invis/Iosevka/releases/latest \
-        | grep -Po '(?<=tag/v)[0-9.]*')
+    FONT_VERSION=$(curl -s -L https://github.com/be5invis/Iosevka/releases/latest \
+        | grep -Po '(?<=tag/v)[0-9.]*' | head -1)
 fi
+
+echo FONT_VERSION="$FONT_VERSION"
 
 echo "Downloading and checking the validity of the source code..."
 
@@ -55,4 +57,3 @@ fi
 
 # Copy the dist folder back to the mounted volume
 cp -r dist /build/
-


### PR DESCRIPTION
See: https://github.com/be5invis/Iosevka/issues/1340

This PR adds some messaging and checks.

From the very beginning of the `run.sh` script:

1) It prints which build-plans file it's gonna use
2) It prints which build plan it's gonna use
3) It doesn't dismiss the build plan anymore when there is no custom build-plains file. It's getting passed down to `npm run build`.

Sample session, without custom build-plans file and build plan:
```
$ docker run -it -v $(pwd):/build avivace/iosevka-build
Custom build-plans file not found, using the default one
Using build plan: contents::iosevka
Using font version: 15.2.0
Downloading and checking the validity of the source code...
...
```

With custom build-plans file, but without a build plan:
```
$ docker run -it -v $(pwd):/build avivace/iosevka-build
Found custom build-plans file: private-build-plans.toml
Using build plan: contents::iosevka-sans-q
Using font version: 15.2.0
Downloading and checking the validity of the source code...
...
```

With custom build-plans file and custom build plan:
```
$ docker run -it -v $(pwd):/build avivace/iosevka-build ttf::iosevka-sans-q
Found custom build-plans file: private-build-plans.toml
Using build plan: ttf::iosevka-sans-q
Using font version: 15.2.0
Downloading and checking the validity of the source code...
...
```

